### PR TITLE
Add InvalidFilterValue exception for more graceful error handling

### DIFF
--- a/pycraigslist/exceptions.py
+++ b/pycraigslist/exceptions.py
@@ -8,3 +8,13 @@ Contains the set of pycraigslist's exceptions.
 
 class MaximumRequestsError(Exception):
     """Exceeds maximum get requests."""
+
+
+class InvalidFilterValue(ValueError):
+    """Search filter has no or an invalid value."""
+
+    def __init__(self, message, name, value):
+        self.message = message
+        self.name = name
+        self.value = value
+        super(InvalidFilterValue, self).__init__(message)

--- a/pycraigslist/query/filters.py
+++ b/pycraigslist/query/filters.py
@@ -7,6 +7,7 @@ Handles parsing of Craigslist query filters.
 
 from pycraigslist.query import sessions
 from pycraigslist.filters import region
+from pycraigslist.exceptions import InvalidFilterValue
 
 
 def get_addl_filters_readable(url):
@@ -55,7 +56,7 @@ def parse_filters(filters, query_filters, **kwargs):
             try:
                 filters[key] = [query_filters[key][parsed_val] for parsed_val in parse_value(value)]
             except (KeyError, TypeError):
-                raise ValueError("filter '%s' is or has a bad value" % key)
+                raise InvalidFilterValue("filter '%s' is or has a bad value" % key, key, value)
 
     # Join default parameters for every filter.
     return {**{"searchNearby": 1, "s": 0}, **filters}

--- a/tests/test_api/test_query.py
+++ b/tests/test_api/test_query.py
@@ -9,7 +9,7 @@ and .search_detail methods.
 import warnings
 from functools import partial
 
-from pytest import mark
+from pytest import mark, param
 
 import specs
 import pycraigslist
@@ -107,3 +107,37 @@ def test_query_filters(parent, filters):
 def test_valid_instantiation(valid_instance):
     """Tests proper instantiation of pycraigslist.api.* instances using valid kwargs."""
     assert type(valid_instance()).__bases__[0] == pycraigslist.base.BaseAPI
+
+
+@mark.parametrize(
+    ["input", "expected"],
+    [
+        param("1", ["1"], id="String"),
+        param(1.0, [1.0], id="Float"),
+        param(True, [True], id="Boolean"),
+        param(1, [1], id="Integer"),
+        param(["1", "2"], ["1", "2"], id="List of integers"),
+        param([1.0, 2.0], [1.0, 2.0], id="List of integers"),
+        param([True, False], [True, False], id="List of integers"),
+        param([1, 2], [1, 2], id="List of integers"),
+        param(["1", 1, 1.0, True], ["1", 1, 1.0, True], id="Mixed list of types"),
+    ],
+)
+def test_parse_value(input, expected):
+    output = pycraigslist.query.filters.parse_value(input)
+    if isinstance(output, list):
+        assert output == expected
+    else:
+        assert list(output) == expected
+
+
+@mark.parametrize(
+    ["input", "modifications", "expected"],
+    [
+        param({"a": True}, {"a": False}, {"a": False}),
+        param({"a": True, "b": True}, {"a": False}, {"a": False, "b": True}),
+        param({"a": True}, {"b": True}, {"a": True, "b": True}),
+    ],
+)
+def test_parse_arg_filters(input, modifications, expected):
+    assert pycraigslist.query.filters.parse_arg_filters(input, **modifications) == expected


### PR DESCRIPTION
Fix #8 by adding a new custom exception, InvalidFilterValue, which will allow for more graceful error handling in scenarios where a Craigslist search filter does not have a valid value.

Also added a few basic unit tests for some underlying filter argument/value parsing functions.